### PR TITLE
process: rm colored logging

### DIFF
--- a/process/logging.go
+++ b/process/logging.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"net/url"
 	"os"
-	"runtime"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
@@ -53,11 +52,7 @@ func NewLogger() (*zap.Logger, error) {
 
 // NewLoggerWithOutputPaths is the same as NewLogger, but overrides the log output paths.
 func NewLoggerWithOutputPaths(outputPaths ...string) (*zap.Logger, error) {
-	levelEncoder := zapcore.CapitalColorLevelEncoder
-	if runtime.GOOS == "windows" {
-		levelEncoder = zapcore.CapitalLevelEncoder
-	}
-
+	levelEncoder := zapcore.CapitalLevelEncoder
 	timeKey := "T"
 	if os.Getenv("STORJ_LOG_NOTIME") != "" {
 		// using environment variable STORJ_LOG_NOTIME to avoid additional flags


### PR DESCRIPTION
This PR removes the colored logger because it adds characters to the log message log level.  Currently when trying to search for logs in GCP log viewer, the log level is not being parsed correctly because of these extra chars.

For example, using the colored logger makes the log level look like this:
`"L":"\u001b[34mINFO\u001b[0m"`

Removing the color makes the log look how we would expect:
`"L":"INFO"`

For example, running storj-sim with these 2 different options produces logs like this:

```
satellite-migration/0      10:34:26.197 | {"L":"\u001b[34mINFO\u001b[0m","C":"process/exec_conf.go:269","M":"Configuration loaded from: /Users/Jessica/Library/Application Support/Storj/Local-Network/
```

versus

```
satellite-migration/0       10:36:05.181 | {"L":"INFO","C":"process/exec_conf.go:269","M":"Configuration loaded from: /Users/Jessica/Library/Application Support/Storj/Local-Network/satellite/0/config.yaml"}
```

