### PR TITLE
Golangci lint v1.43.0 changes

### DIFF
--- a/process/decorate_notwindows.go
+++ b/process/decorate_notwindows.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2020 Storj Labs, Inc.
 // See LICENSE for copying information.
 
+//go:build !windows
 // +build !windows
 
 package process

--- a/tagsql/tracker_norace.go
+++ b/tagsql/tracker_norace.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2020 Storj Labs, Inc.
 // See LICENSE for copying information.
 
+//go:build !race
 // +build !race
 
 package tagsql

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -67,9 +67,9 @@ func TestSemVer_Compare(t *testing.T) {
 	require.NoError(t, err)
 
 	// compare the same values
-	require.True(t, version001.Compare(version001) == 0)
-	require.True(t, version030.Compare(version030) == 0)
-	require.True(t, version500.Compare(version500) == 0)
+	require.True(t, version001.Compare(version001) == 0) //nolint: gocritic
+	require.True(t, version030.Compare(version030) == 0) //nolint: gocritic
+	require.True(t, version500.Compare(version500) == 0) //nolint: gocritic
 
 	require.True(t, version001.Compare(version002) < 0)
 	require.True(t, version030.Compare(version040) < 0)


### PR DESCRIPTION
Changes to fix or ignore errors returned by golangci-lint v1.43.0

dupArg: suspicious method call with the same argument and receiver (gocritic)
File is not gofmt-ed with -s (gofmt)

See https://github.com/storj/ci/pull/39